### PR TITLE
Properly handle extension dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # Change Log
 
 ## [Unreleased]
+
+### Fixed
+
+- Fixed game extensions not being handled
+
 ## [0.9.9] 2024-03-17
 
 ### Changed

--- a/src/mod-installer.ts
+++ b/src/mod-installer.ts
@@ -58,9 +58,52 @@ export class ModInstaller {
             } as ModEntryLocal,
             'post-game': {
                 id: 'post-game',
-                name: 'DLC',
-                description: 'CrossCode DLC.',
+                name: 'Post Game DLC',
+                description: 'The postgame DLC.',
                 version: LocalMods.getCCVersion(),
+                isExtension: true,
+            } as ModEntryLocal,
+            'manlea': {
+                id: 'manlea',
+                name: 'Manlea',
+                description: 'The Manlea skin DLC.',
+                version: LocalMods.getCCVersion(),
+                isExtension: true,
+            } as ModEntryLocal,
+            'ninja-skin': {
+                id: 'ninja-skin',
+                name: 'Ninja Skin',
+                description: 'The ninja skin DLC.',
+                version: LocalMods.getCCVersion(),
+                isExtension: true,
+            } as ModEntryLocal,
+            'scorpion-robo': {
+                id: 'scorpion-robo',
+                name: 'PC Exclusive Extension',
+                description: 'The formerly exclusive PC content.',
+                version: LocalMods.getCCVersion(),
+                isExtension: true,
+            } as ModEntryLocal,
+            'snowman-tank': {
+                id: 'snowman-tank',
+                name: 'Xbox Exclusive Extension',
+                description: 'The formerly exclusive Xbox One content.',
+                version: LocalMods.getCCVersion(),
+                isExtension: true,
+            } as ModEntryLocal,
+            'fish-gear': {
+                id: 'fish-gear',
+                name: 'PS4 Exclusive Extension',
+                description: 'The formerly exclusive PS4 content.',
+                version: LocalMods.getCCVersion(),
+                isExtension: true,
+            } as ModEntryLocal,
+            'flying-hedgehag': {
+                id: 'flying-hedgehag',
+                name: 'Switch Exclusive Extension',
+                description: 'The formerly exclusive Nintendo Switch content.',
+                version: LocalMods.getCCVersion(),
+                isExtension: true,
             } as ModEntryLocal,
         }
     }
@@ -84,6 +127,9 @@ export class ModInstaller {
         for (const depName in mod.dependencies) {
             const reqVersionRange = mod.dependencies[depName]
             if (this.virtualMods[depName]) {
+                if(this.virtualMods[depName].isExtension && !ig.extensions.hasExtension(depName)) {
+                    throw new Error(`Mod: ${mod.id} has a dependant extension missing: ${depName}`)
+                }
                 this.setOrAddNewer(deps, { id: depName } as any, reqVersionRange)
                 continue
             }

--- a/src/mod-installer.ts
+++ b/src/mod-installer.ts
@@ -1,6 +1,6 @@
 import { LocalMods } from './local-mods'
 import { ModDB } from './moddb'
-import { ModEntry, ModEntryLocal, ModEntryServer } from './types'
+import { ModEntry, ModEntryBaseBase, ModEntryLocal, ModEntryLocalVirtual, ModEntryServer } from './types'
 import { ModInstallDialogs } from './gui/install-dialogs'
 
 const fs: typeof import('fs') = (0, eval)("require('fs')")
@@ -46,7 +46,7 @@ type DepEntry = { mod: ModEntryServer; versionReqRanges: string[] }
 export class ModInstaller {
     static record: Record<string, ModEntryServer>
     static byNameRecord: Record<string, ModEntryServer>
-    static virtualMods: Record<string, ModEntryLocal>
+    static virtualMods: Record<string, ModEntryLocalVirtual>
 
     static init() {
         this.virtualMods = {
@@ -55,56 +55,56 @@ export class ModInstaller {
                 name: 'CrossCode',
                 description: 'The base game.',
                 version: LocalMods.getCCVersion(),
-            } as ModEntryLocal,
+            },
             'post-game': {
                 id: 'post-game',
                 name: 'Post Game DLC',
                 description: 'The postgame DLC.',
                 version: LocalMods.getCCVersion(),
                 isExtension: true,
-            } as ModEntryLocal,
-            'manlea': {
+            },
+            manlea: {
                 id: 'manlea',
                 name: 'Manlea',
                 description: 'The Manlea skin DLC.',
                 version: LocalMods.getCCVersion(),
                 isExtension: true,
-            } as ModEntryLocal,
+            },
             'ninja-skin': {
                 id: 'ninja-skin',
                 name: 'Ninja Skin',
                 description: 'The ninja skin DLC.',
                 version: LocalMods.getCCVersion(),
                 isExtension: true,
-            } as ModEntryLocal,
+            },
             'scorpion-robo': {
                 id: 'scorpion-robo',
                 name: 'PC Exclusive Extension',
                 description: 'The formerly exclusive PC content.',
                 version: LocalMods.getCCVersion(),
                 isExtension: true,
-            } as ModEntryLocal,
+            },
             'snowman-tank': {
                 id: 'snowman-tank',
                 name: 'Xbox Exclusive Extension',
                 description: 'The formerly exclusive Xbox One content.',
                 version: LocalMods.getCCVersion(),
                 isExtension: true,
-            } as ModEntryLocal,
+            },
             'fish-gear': {
                 id: 'fish-gear',
                 name: 'PS4 Exclusive Extension',
                 description: 'The formerly exclusive PS4 content.',
                 version: LocalMods.getCCVersion(),
                 isExtension: true,
-            } as ModEntryLocal,
+            },
             'flying-hedgehag': {
                 id: 'flying-hedgehag',
                 name: 'Switch Exclusive Extension',
                 description: 'The formerly exclusive Nintendo Switch content.',
                 version: LocalMods.getCCVersion(),
                 isExtension: true,
-            } as ModEntryLocal,
+            },
         }
     }
 
@@ -127,7 +127,7 @@ export class ModInstaller {
         for (const depName in mod.dependencies) {
             const reqVersionRange = mod.dependencies[depName]
             if (this.virtualMods[depName]) {
-                if(this.virtualMods[depName].isExtension && !ig.extensions.hasExtension(depName)) {
+                if (this.virtualMods[depName].isExtension && !ig.extensions.hasExtension(depName)) {
                     throw new Error(`Mod: ${mod.id} has a dependant extension missing: ${depName}`)
                 }
                 this.setOrAddNewer(deps, { id: depName } as any, reqVersionRange)
@@ -148,7 +148,7 @@ export class ModInstaller {
         return deps
     }
 
-    private static matchesVersionReqRanges(mod: ModEntry, versionReqRanges: string[]) {
+    private static matchesVersionReqRanges(mod: ModEntryBaseBase, versionReqRanges: string[]) {
         for (const range of versionReqRanges) {
             if (!semver_satisfies(mod.version, range)) return false
         }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -90,12 +90,19 @@ export type NPDatabasePackageInstallation = {
     source: string
 }
 
-interface ModEntryBase {
-    database: string
+export interface ModEntryBaseBase {
     id: string
     name: string
     description?: string
     version: string
+}
+
+export interface ModEntryLocalVirtual extends ModEntryBaseBase {
+    isExtension?: boolean
+}
+
+interface ModEntryBase extends ModEntryBaseBase {
+    database: string
     isLegacy: boolean
     hasIcon: boolean
     dependencies: Record<string, string>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -126,6 +126,7 @@ export interface ModEntryLocal extends ModEntryBase {
     disableDisabling?: boolean
     disableUpdate?: boolean
     isGit?: boolean
+    isExtension?: boolean
 }
 
 export type ModEntry = ModEntryServer | ModEntryLocal

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -133,7 +133,6 @@ export interface ModEntryLocal extends ModEntryBase {
     disableDisabling?: boolean
     disableUpdate?: boolean
     isGit?: boolean
-    isExtension?: boolean
 }
 
 export type ModEntry = ModEntryServer | ModEntryLocal


### PR DESCRIPTION
Currently, the mod manager simply _assumes_ that one who uses the mod manager has the post-game installed, and never acknowledges any other extension's existence. It is perfectly valid for a mod to depend on, for example the Manlea skin and the mod manager would be unable to properly handle that.

For consistency, all 4 platform extensions are included even if dependence on them is unlikely.