### PR TITLE
Remove `npx` from `script`s

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
     "name": "ccmodmanager",
     "version": "1.0.4",
     "scripts": {
-        "start": "npx esbuild --target=es2018 --format=esm --platform=node --bundle --sourcemap=inline --outfile=plugin.js src/plugin.ts",
-        "watch": "npx esbuild --target=es2018 --format=esm --platform=node --bundle --sourcemap=inline --watch --outfile=plugin.js src/plugin.ts",
-        "build": "npx esbuild --target=es2018 --format=esm --platform=node --bundle --outfile=plugin.js --minify-syntax --minify-whitespace src/plugin.ts",
-        "format": "prettier ./src -w; npx prettier ./assets -w --tab-width 4 --no-semi --print-width 500 --bracket-same-line",
+        "start": "esbuild --target=es2018 --format=esm --platform=node --bundle --sourcemap=inline --outfile=plugin.js src/plugin.ts",
+        "watch": "esbuild --target=es2018 --format=esm --platform=node --bundle --sourcemap=inline --watch --outfile=plugin.js src/plugin.ts",
+        "build": "esbuild --target=es2018 --format=esm --platform=node --bundle --outfile=plugin.js --minify-syntax --minify-whitespace src/plugin.ts",
+        "format": "prettier ./src -w; prettier ./assets -w --tab-width 4 --no-semi --print-width 500 --bracket-same-line",
         "types": "tsc --noEmit false --outDir types --emitDeclarationOnly true --declaration --isolatedModules false"
     },
     "license": "GPLv3",


### PR DESCRIPTION
Removes the redundant `npx` calls, as the dependency binaries are already [included in the path](https://docs.npmjs.com/cli/v6/using-npm/scripts#path) when running `script`s (the link is to the npm docs but [pnpm does this too](https://pnpm.io/cli/run#details)). `npx` takes quite a bit of time to run, so this speeds up the scripts:

```js
~$ # npx
~$ hyperfine --warmup 5 'pnpm build'
Benchmark 1: pnpm build
  Time (mean ± σ):     553.2 ms ±  21.5 ms    [User: 358.4 ms, System: 84.8 ms]
  Range (min … max):   531.0 ms … 607.9 ms    10 runs

~$ # without npx
~$ hyperfine --warmup 5 'pnpm build'
Benchmark 1: pnpm build
  Time (mean ± σ):     247.7 ms ±   9.0 ms    [User: 199.2 ms, System: 36.4 ms]
  Range (min … max):   234.5 ms … 259.4 ms    11 runs
```

On my computer, it shaves off ~300ms of time.

---

Also, in the build instructions in the README, the `npx tsc` can be replaced with `pnpm tsc`, as pnpm [would resolve that into running the binary](https://github.com/pnpm/pnpm/releases/tag/v6.6.2), though I didn't do that in this PR because I wasn't sure if that change would have been rejected.